### PR TITLE
This is required for later linking the library when Python is enabled.

### DIFF
--- a/hermes_common/include/solvers/eigensolver.h
+++ b/hermes_common/include/solvers/eigensolver.h
@@ -27,7 +27,7 @@
 
 #include "../matrix.h"
 
-#include "python_api.h"
+#include "python_API/python_api.h"
 
 // RCP
 #ifndef WITH_TRILINOS


### PR DESCRIPTION
Please try if it doesn't break _your_ linking.
