### PR TITLE
fix in damping coefficient calculation. Not sure about that, please look at it carefully. This is potential source of errors difficult to find. But I thing, that it was really wrong up to now.

### DIFF
--- a/hermes2d/src/solver/newton_solver.cpp
+++ b/hermes2d/src/solver/newton_solver.cpp
@@ -687,9 +687,8 @@ namespace Hermes
             // Try with the different damping factor.
             // Important thing here is the factor used that must be calculated from the current one and the previous one.
             // This results in the following relation (since the damping factor is only updated one way).
-            double factor = damping_factors.back() * (1 - this->auto_damping_ratio);
             for (int i = 0; i < ndof; i++)
-              coeff_vec[i] = coeff_vec_back[i] + factor * (coeff_vec[i] - coeff_vec_back[i]);
+              coeff_vec[i] = coeff_vec_back[i] + (coeff_vec[i] - coeff_vec_back[i]) / this->auto_damping_ratio;
 
             // Add new solution norm.
             solution_norms.push_back(get_l2_norm(coeff_vec, this->ndof));


### PR DESCRIPTION
previously not correct. Since auto_damping_ratio > 1 (implicityly == 2),  damping_factors.back() \* (1 - this->auto_damping_ratio) does not make sense.
Using this calculations, real damping factors were as follows: 1, -1/2, 1/8, ....
