### PR TITLE
Modifying the Hermes binary format.

### DIFF
--- a/hermes_common/src/cs_matrix.cpp
+++ b/hermes_common/src/cs_matrix.cpp
@@ -414,10 +414,14 @@ namespace Hermes
 
       case DF_HERMES_BIN:
         {
-          hermes_fwrite("HERMESX\001", 1, 8, file);
+          //hermes_fwrite("HERMESX\001", 1, 8, file);
           int ssize = sizeof(double);
-          hermes_fwrite(&ssize, sizeof(int), 1, file);
+          int njc = this->size+1;
+          //hermes_fwrite(&ssize, sizeof(int), 1, file);
           hermes_fwrite(&this->size, sizeof(int), 1, file);
+          hermes_fwrite(&nnz, sizeof(int), 1, file);
+          hermes_fwrite(&njc, sizeof(int), 1, file); 
+          hermes_fwrite(&nnz, sizeof(int), 1, file);
           hermes_fwrite(&nnz, sizeof(int), 1, file);
           hermes_fwrite(Ap, sizeof(int), this->size + 1, file);
           hermes_fwrite(Ai, sizeof(int), nnz, file);
@@ -519,10 +523,14 @@ namespace Hermes
 
       case DF_HERMES_BIN:
         {
-          hermes_fwrite("HERMESX\001", 1, 8, file);
+          //hermes_fwrite("HERMESX\001", 1, 8, file);
           int ssize = sizeof(std::complex<double>);
-          hermes_fwrite(&ssize, sizeof(int), 1, file);
+          int njc = this->size+1;
+          //hermes_fwrite(&ssize, sizeof(int), 1, file);
           hermes_fwrite(&this->size, sizeof(int), 1, file);
+          hermes_fwrite(&nnz, sizeof(int), 1, file);
+          hermes_fwrite(&njc, sizeof(int), 1, file); 
+          hermes_fwrite(&nnz, sizeof(int), 1, file);
           hermes_fwrite(&nnz, sizeof(int), 1, file);
           hermes_fwrite(Ap, sizeof(int), this->size + 1, file);
           hermes_fwrite(Ai, sizeof(int), nnz, file);
@@ -754,10 +762,14 @@ namespace Hermes
 
       case DF_HERMES_BIN:
         {
-          hermes_fwrite("HERMESX\001", 1, 8, file);
+          //hermes_fwrite("HERMESX\001", 1, 8, file);
           int ssize = sizeof(double);
-          hermes_fwrite(&ssize, sizeof(int), 1, file);
+          int njc = this->size+1;
+          //hermes_fwrite(&ssize, sizeof(int), 1, file);
           hermes_fwrite(&this->size, sizeof(int), 1, file);
+          hermes_fwrite(&nnz, sizeof(int), 1, file);
+          hermes_fwrite(&njc, sizeof(int), 1, file);
+          hermes_fwrite(&nnz, sizeof(int), 1, file);
           hermes_fwrite(&nnz, sizeof(int), 1, file);
           hermes_fwrite(Ap, sizeof(int), this->size + 1, file);
           hermes_fwrite(Ai, sizeof(int), nnz, file);

--- a/hermes_common/src/solvers/umfpack_solver.cpp
+++ b/hermes_common/src/solvers/umfpack_solver.cpp
@@ -171,9 +171,9 @@ namespace Hermes
 
       case DF_HERMES_BIN:
         {
-          hermes_fwrite("HERMESR\001", 1, 8, file);
-          int ssize = sizeof(double);
-          hermes_fwrite(&ssize, sizeof(int), 1, file);
+          //hermes_fwrite("HERMESR\001", 1, 8, file);
+          //int ssize = sizeof(double);
+          //hermes_fwrite(&ssize, sizeof(int), 1, file);
           hermes_fwrite(&this->size, sizeof(int), 1, file);
           hermes_fwrite(v, sizeof(double), this->size, file);
           return true;


### PR DESCRIPTION
Ad-hoc modifikace pro pouziti s matio.c. Asi spis jen pro info, mozna systemovejsi by bylo vytvorit neco jako DF_HERMES_MATLAB_BIN a rovnou k tomu pridat i volani prislusnych funkci z matio, aby vysledkem byl kompletni pouzitelny .mat soubor...
