### PR TITLE
implemented matio library for export MATLAB binary mat files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,9 @@ project(hermes)
   # BSON 
   set(WITH_BSON NO)
 
+  # MATIO
+  set(WITH_MATIO NO)
+
   #### Solvers ###
   # Standard UMFPACK
     # UMFPACK is chosen by default.
@@ -303,6 +306,19 @@ project(hermes)
       endif(WITH_BSON)
     ENDIF()
 
+    IF(DEFINED MATIO_LIBRARY)
+      IF(DEFINED MATIO_INCLUDE_DIR)
+        include_directories(${MATIO_INCLUDE_DIR})
+      ELSE()
+        MESSAGE(FATAL_ERROR When MATIO_LIBRARY is defined, so must be MATIO_INCLUDE_DIR.)
+      ENDIF()
+    ELSE()
+      if(WITH_MATIO)
+        find_package(MATIO REQUIRED)
+        include_directories(${MATIO_INCLUDE_DIR})
+      endif(WITH_MATIO)
+    ENDIF()
+
     find_package(XSD REQUIRED)
     find_package(XERCES REQUIRED)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -465,6 +481,7 @@ project(hermes)
   message("Build with MPI: ${WITH_MPI}")
   message("Build with EXODUSII: ${WITH_EXODUSII}")
   message("Build with BSON: ${WITH_BSON}")
+  message("Build with MATIO: ${WITH_MATIO}")
   
   message("---------------------")
   message("Hermes common library:")

--- a/cmake/BuildAndInstallScripts.cmake
+++ b/cmake/BuildAndInstallScripts.cmake
@@ -1,21 +1,27 @@
 # Macro for generating classes for XML mesh parsing according to XSD
 macro(GENERATE_XSD_FILES PROJECT_NAME HEADER_XML_FILE_OUTPUT SOURCE_XML_FILE_OUTPUT XSD_FILE TARGET_DIR)
   add_custom_target(${PROJECT_NAME} ALL DEPENDS ${HEADER_XML_FILE_OUTPUT} ${SOURCE_XML_FILE_OUTPUT})
-  
-  IF(WIN32)
-    ADD_CUSTOM_COMMAND(
-    OUTPUT ${HEADER_XML_FILE_OUTPUT} ${SOURCE_XML_FILE_OUTPUT}
-    COMMAND ${XSD_BIN} ARGS cxx-tree --generate-doxygen --generate-ostream --hxx-suffix .h --cxx-suffix .cpp --root-element-first --generate-polymorphic --generate-serialization --output-dir include/${TARGET_DIR} ${XSD_FILE}
-    COMMAND move ARGS "/Y" "${PROJECT_SOURCE_DIR}\\include\\${TARGET_DIR}\\*.cpp" "${PROJECT_SOURCE_DIR}\\src\\${TARGET_DIR}"
-    DEPENDS ${XSD_FILE} ${HEADER_XML_FILE_OUTPUT} ${SOURCE_XML_FILE_OUTPUT})
-  ELSE()
-    ADD_CUSTOM_COMMAND(
-    OUTPUT ${HEADER_XML_FILE_OUTPUT} ${SOURCE_XML_FILE_OUTPUT}
-    COMMAND ${XSD_BIN} ARGS cxx-tree --generate-doxygen --generate-ostream --hxx-suffix .h --cxx-suffix .cpp --root-element-first --generate-polymorphic --generate-serialization --output-dir include/${TARGET_DIR} ${XSD_FILE}
-    COMMAND mv ARGS "-f" "${PROJECT_SOURCE_DIR}/include/${TARGET_DIR}/*.cpp" "${PROJECT_SOURCE_DIR}/src/${TARGET_DIR}/"
-    DEPENDS ${XSD_FILE} ${HEADER_XML_FILE_OUTPUT} ${SOURCE_XML_FILE_OUTPUT})
-  ENDIF()
-  
+
+IF(WIN32)
+  ADD_CUSTOM_COMMAND(
+        SOURCE    ${XSD_FILE}
+        COMMAND   ${XSD_BIN} ARGS cxx-tree --generate-doxygen --generate-ostream --hxx-suffix .h --cxx-suffix .cpp --root-element-first --generate-polymorphic --generate-serialization --output-dir include/${TARGET_DIR} ${XSD_FILE}
+        COMMAND   move ARGS "/Y" "${PROJECT_SOURCE_DIR}\\include\\${TARGET_DIR}\\*.cpp" "${PROJECT_SOURCE_DIR}\\src\\${TARGET_DIR}"
+        TARGET    ${PROJECT_NAME}
+        OUTPUTS   ${HEADER_XML_FILE_OUTPUT} ${SOURCE_XML_FILE_OUTPUT})
+ELSE()
+  ADD_CUSTOM_COMMAND(
+        SOURCE    ${XSD_FILE}
+        COMMAND   ${XSD_BIN} ARGS cxx-tree --generate-doxygen --generate-ostream --hxx-suffix .h --cxx-suffix .cpp --root-element-first --generate-polymorphic --generate-serialization --output-dir include/${TARGET_DIR} ${XSD_FILE}
+        COMMAND   mv ARGS "-f" "${PROJECT_SOURCE_DIR}/include/${TARGET_DIR}/*.cpp" "${PROJECT_SOURCE_DIR}/src/${TARGET_DIR}/"
+        TARGET    ${PROJECT_NAME}
+        OUTPUTS   ${HEADER_XML_FILE_OUTPUT} ${SOURCE_XML_FILE_OUTPUT})
+ENDIF()
+ADD_CUSTOM_COMMAND(
+      SOURCE    ${PROJECT_NAME}
+      TARGET    ${PROJECT_NAME}
+      DEPENDS   ${HEADER_XML_FILE_OUTPUT} ${SOURCE_XML_FILE_OUTPUT})
+
 endmacro(GENERATE_XSD_FILES)
 
 # MSVC (Win) helper macros
@@ -40,11 +46,11 @@ endmacro(ADD_MSVC_BUILD_FLAGS)
 # Installs a library to directories relative to CMAKE_INSTALL_PREFIX.
 macro(INSTALL_LIB LIB)
 	install(TARGETS ${LIB} 
-				RUNTIME DESTINATION ${TARGET_ROOT}/bin 
-				LIBRARY DESTINATION ${TARGET_ROOT}/lib 
-				ARCHIVE DESTINATION ${TARGET_ROOT}/lib)
+                RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+                LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 	if (MSVC)
-	  MAKE_PATH(TARGET_DIR "${TARGET_ROOT}/bin")
+      MAKE_PATH(TARGET_DIR "${CMAKE_INSTALL_PREFIX}/bin")
     get_target_property(SOURCE_DEBUG_FILE ${LIB} LOCATION_Debug)
     MAKE_PATH(SOURCE_DEBUG_FILE ${SOURCE_DEBUG_FILE})
     get_target_property(SOURCE_RELEASE_FILE ${LIB} LOCATION_Release)

--- a/cmake/FindMATIO.cmake
+++ b/cmake/FindMATIO.cmake
@@ -1,0 +1,16 @@
+#
+# MATIO
+# FROM http://sourceforge.net/projects/matio/
+#
+
+FIND_PATH(MATIO_INCLUDE_DIR matio.h ${MATIO_ROOT}/src ${MATIO_ROOT}/include /usr/local/include /usr/include)
+
+if(WIN64)
+  FIND_LIBRARY(MATIO_LIBRARY NAMES agros2d_3rd_party_matio matio PATHS ${MATIO_ROOT} ${MATIO_ROOT}/lib/x64 ${MATIO_ROOT})
+else(WIN64)  
+  FIND_LIBRARY(MATIO_LIBRARY NAMES agros2d_3rd_party_matio matio PATHS ${MATIO_ROOT} ${MATIO_ROOT}/lib /usr/lib /usr/local/lib /usr/lib64 /usr/local/lib64)
+endif(WIN64)
+
+# Report the found libraries, quit with fatal error if any required library has not been found.
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(BSON DEFAULT_MSG MATIO_LIBRARY MATIO_INCLUDE_DIR)

--- a/hermes2d/include/solver/newton_solver.h
+++ b/hermes2d/include/solver/newton_solver.h
@@ -105,7 +105,7 @@ namespace Hermes
       /// Default: this->set_tolerance(1e-8, ResidualNormAbsolute);
       /// \param[in] handleMultipleTolerancesAnd If true, multiple tolerances defined will have to be all fulfilled in order to proclaim
       /// solution as a correct one. If false, only one will be enough.
-      void set_tolerance(double newton_tol, NewtonSolverConvergenceMeasurementType toleranceType, bool handleMultipleTolerancesAnd = true);
+      void set_tolerance(double newton_tol, NewtonSolverConvergenceMeasurementType toleranceType, bool handleMultipleTolerancesAnd = false);
 
 #pragma region damping-public
       /// Sets minimum damping coefficient.

--- a/hermes2d/src/mixins2d.cpp
+++ b/hermes2d/src/mixins2d.cpp
@@ -41,8 +41,8 @@ namespace Hermes
 
       template<typename Scalar>
       MatrixRhsOutput<Scalar>::MatrixRhsOutput() : output_matrixOn(false), output_matrixIterations(-1), matrixFilename("Matrix_"),
-        matrixVarname("A"), matrixFormat(Hermes::Algebra::DF_MATLAB_SPARSE), matrix_number_format("%lf"), output_rhsOn(false), output_rhsIterations(-1),
-        RhsFilename("Rhs_"), RhsVarname("b"), RhsFormat(Hermes::Algebra::DF_MATLAB_SPARSE), rhs_number_format("%lf")
+        matrixVarname("A"), matrixFormat(Hermes::Algebra::DF_PLAIN_ASCII), matrix_number_format("%lf"), output_rhsOn(false), output_rhsIterations(-1),
+        RhsFilename("Rhs_"), RhsVarname("b"), RhsFormat(Hermes::Algebra::DF_PLAIN_ASCII), rhs_number_format("%lf")
       {
       }
 
@@ -55,14 +55,8 @@ namespace Hermes
         if(this->output_matrixOn && (this->output_matrixIterations == -1 || this->output_matrixIterations >= iteration))
         {
           char* fileName = new char[this->matrixFilename.length() + 5];
-          if(this->matrixFormat == Hermes::Algebra::DF_MATLAB_SPARSE)
-            sprintf(fileName, "%s%i.m", this->matrixFilename.c_str(), iteration);
-          else
-            sprintf(fileName, "%s%i", this->matrixFilename.c_str(), iteration);
-          FILE* matrix_file = fopen(fileName, "w+");
-
-          matrix->dump(matrix_file, this->matrixVarname.c_str(), this->matrixFormat, this->matrix_number_format);
-          fclose(matrix_file);
+          sprintf(fileName, "%s%i", this->matrixFilename.c_str(), iteration);
+          matrix->dump(fileName, this->matrixVarname.c_str(), this->matrixFormat, this->matrix_number_format);
           delete [] fileName;
         }
       }
@@ -76,14 +70,8 @@ namespace Hermes
         if(this->output_matrixOn)
         {
           char* fileName = new char[this->matrixFilename.length() + 5];
-          if(this->matrixFormat == Hermes::Algebra::DF_MATLAB_SPARSE)
-            sprintf(fileName, "%s.m", this->matrixFilename.c_str());
-          else
-            sprintf(fileName, "%s", this->matrixFilename.c_str());
-          FILE* matrix_file = fopen(fileName, "w+");
-
-          matrix->dump(matrix_file, this->matrixVarname.c_str(), this->matrixFormat, this->matrix_number_format);
-          fclose(matrix_file);
+          sprintf(fileName, "%s", this->matrixFilename.c_str());
+          matrix->dump(fileName, this->matrixVarname.c_str(), this->matrixFormat, this->matrix_number_format);
           delete [] fileName;
         }
       }
@@ -97,13 +85,8 @@ namespace Hermes
         if(this->output_rhsOn && (this->output_rhsIterations == -1 || this->output_rhsIterations >= iteration))
         {
           char* fileName = new char[this->RhsFilename.length() + 5];
-          if(this->RhsFormat == Hermes::Algebra::DF_MATLAB_SPARSE)
-            sprintf(fileName, "%s%i.m", this->RhsFilename.c_str(), iteration);
-          else
-            sprintf(fileName, "%s%i", this->RhsFilename.c_str(), iteration);
-          FILE* rhs_file = fopen(fileName, "w+");
-          rhs->dump(rhs_file, this->RhsVarname.c_str(), this->RhsFormat, this->rhs_number_format);
-          fclose(rhs_file);
+          sprintf(fileName, "%s%i", this->RhsFilename.c_str(), iteration);
+          rhs->dump(fileName, this->RhsVarname.c_str(), this->RhsFormat, this->rhs_number_format);
           delete [] fileName;
         }
       }
@@ -117,13 +100,8 @@ namespace Hermes
         if(this->output_rhsOn)
         {
           char* fileName = new char[this->RhsFilename.length() + 5];
-          if(this->RhsFormat == Hermes::Algebra::DF_MATLAB_SPARSE)
-            sprintf(fileName, "%s.m", this->RhsFilename.c_str());
-          else
-            sprintf(fileName, "%s", this->RhsFilename.c_str());
-          FILE* rhs_file = fopen(fileName, "w+");
-          rhs->dump(rhs_file, this->RhsVarname.c_str(), this->RhsFormat, this->rhs_number_format);
-          fclose(rhs_file);
+          sprintf(fileName, "%s", this->RhsFilename.c_str());
+          rhs->dump(fileName, this->RhsVarname.c_str(), this->RhsFormat, this->rhs_number_format);
           delete [] fileName;
         }
       }

--- a/hermes2d/src/solver/newton_solver.cpp
+++ b/hermes2d/src/solver/newton_solver.cpp
@@ -70,7 +70,7 @@ namespace Hermes
       for(int i = 0; i < NewtonSolverConvergenceMeasurementTypeCount; i++)
         this->newton_tolerance[i] = std::numeric_limits<double>::max();
       memset(this->newton_tolerance_set, 0, sizeof(bool)*NewtonSolverConvergenceMeasurementTypeCount);
-      this->handleMultipleTolerancesAnd = true;
+      this->handleMultipleTolerancesAnd = false;
       this->max_allowed_iterations = 20;
       this->residual_as_function = false;
       this->max_allowed_residual_norm = 1E9;

--- a/hermes2d/src/solver/runge_kutta.cpp
+++ b/hermes2d/src/solver/runge_kutta.cpp
@@ -375,13 +375,8 @@ namespace Hermes
         if(this->output_rhsOn && (this->output_rhsIterations == -1 || this->output_rhsIterations >= it))
         {
           char* fileName = new char[this->RhsFilename.length() + 5];
-          if(this->RhsFormat == Hermes::Algebra::DF_MATLAB_SPARSE)
-            sprintf(fileName, "%s%i.m", this->RhsFilename.c_str(), it);
-          else
-            sprintf(fileName, "%s%i", this->RhsFilename.c_str(), it);
-          FILE* rhs_file = fopen(fileName, "w+");
-          vector_right->dump(rhs_file, this->RhsVarname.c_str(), this->RhsFormat, this->rhs_number_format);
-          fclose(rhs_file);
+          sprintf(fileName, "%s%i", this->RhsFilename.c_str(), it);
+          vector_right->dump(fileName, this->RhsVarname.c_str(), this->RhsFormat, this->rhs_number_format);
         }
 
         // Measure the residual norm.
@@ -437,14 +432,8 @@ namespace Hermes
           if(this->output_matrixOn && (this->output_matrixIterations == -1 || this->output_matrixIterations >= it))
           {
             char* fileName = new char[this->matrixFilename.length() + 5];
-            if(this->matrixFormat == Hermes::Algebra::DF_MATLAB_SPARSE)
-              sprintf(fileName, "%s%i.m", this->matrixFilename.c_str(), it);
-            else
-              sprintf(fileName, "%s%i", this->matrixFilename.c_str(), it);
-            FILE* matrix_file = fopen(fileName, "w+");
-
-            matrix_right->dump(matrix_file, this->matrixVarname.c_str(), this->matrixFormat, this->matrix_number_format);
-            fclose(matrix_file);
+            sprintf(fileName, "%s%i", this->matrixFilename.c_str(), it);
+            matrix_right->dump(fileName, this->matrixVarname.c_str(), this->matrixFormat, this->matrix_number_format);
           }
 
           matrix_right->finish();

--- a/hermes_common/CMakeLists.txt
+++ b/hermes_common/CMakeLists.txt
@@ -150,6 +150,7 @@ project(hermes_common)
       ${BLAS_LIBRARY}
       ${F2C_LIBRARY}
       ${BSON_LIBRARY}
+      ${MATIO_LIBRARY}
       ${WINBLAS_LIBRARY} 
       ${ADDITIONAL_LIBS}
     )

--- a/hermes_common/include/common.h
+++ b/hermes_common/include/common.h
@@ -70,6 +70,10 @@
 #include "bson.h"
 #endif
 
+#ifdef WITH_MATIO
+#include "matio.h"
+#endif
+
 #ifdef WITH_OPENMP
   #include <omp.h>
 #else

--- a/hermes_common/include/cs_matrix.h
+++ b/hermes_common/include/cs_matrix.h
@@ -91,7 +91,7 @@ namespace Hermes
       virtual void set_row_zero(unsigned int n);
 
       /// Utility method.
-      virtual bool dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt = DF_MATLAB_SPARSE, char* number_format = "%lf") = 0;
+      virtual bool dump(char *filename, const char *var_name, EMatrixDumpFormat fmt = DF_PLAIN_ASCII, char* number_format = "%lf") = 0;
       /// Utility method.
       virtual unsigned int get_matrix_size() const;
       /// Utility method.
@@ -150,7 +150,7 @@ namespace Hermes
 
       virtual void add(unsigned int m, unsigned int n, Scalar v);
 
-      virtual bool dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt = DF_MATLAB_SPARSE, char* number_format = "%lf");
+      virtual bool dump(char *filename, const char *var_name, EMatrixDumpFormat fmt = DF_PLAIN_ASCII, char* number_format = "%lf");
 
       friend class Hermes::Solvers::CSCIterator<Scalar>;
 
@@ -190,7 +190,7 @@ namespace Hermes
 
       virtual void add(unsigned int m, unsigned int n, Scalar v);
 
-      virtual bool dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt = DF_MATLAB_SPARSE, char* number_format = "%lf");
+      virtual bool dump(char *filename, const char *var_name, EMatrixDumpFormat fmt = DF_PLAIN_ASCII, char* number_format = "%lf");
 
       friend class Hermes::Solvers::CSCIterator<Scalar>;
 

--- a/hermes_common/include/matrix.h
+++ b/hermes_common/include/matrix.h
@@ -38,7 +38,8 @@ namespace Hermes
     SOLVER_MUMPS = 4,
     SOLVER_SUPERLU = 5,
     SOLVER_AMESOS = 6,
-    SOLVER_AZTECOO = 7
+    SOLVER_AZTECOO = 7,
+    SOLVER_EMPTY = 100
   };
 
   enum DirectMatrixSolverType
@@ -292,17 +293,12 @@ namespace Hermes
     enum EMatrixDumpFormat
     {
       /// \brief Plain ascii file
-      /// first line is matrix size
-      /// second line in number of nonzero values
-      /// next lines contains row column and value
-      DF_MATLAB_SPARSE = 0,
+      /// lines contains row column and value
       DF_PLAIN_ASCII = 1,
-      /// \brief Hermes binary format
-      DF_HERMES_BIN = 2,
-      /// \brief Matrix Market which can be read by pysparse library
-      DF_MATRIX_MARKET = 3,
       /// Binary MATio format
-      DF_HERMES_MATLAB_BIN = 4
+      DF_MATLAB_MAT = 4,
+      /// \brief Matrix Market which can be read by pysparse library
+      DF_MATRIX_MARKET = 3
     };
 
     /// \brief General (abstract) matrix representation in Hermes.
@@ -368,7 +364,7 @@ namespace Hermes
       /// @param[in] var_name name of variable (will be written to output file)
       /// @param[in] fmt output file format
       /// @return true on succes
-      virtual bool dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt = DF_MATLAB_SPARSE, char* number_format = "%lf") = 0;
+      virtual bool dump(char *filename, const char *var_name, EMatrixDumpFormat fmt = DF_PLAIN_ASCII, char* number_format = "%lf") = 0;
 
       /// Get size of matrix
       /// @return size of matrix
@@ -585,8 +581,8 @@ namespace Hermes
       /// @param[in] var_name name of variable (will be written to output file)
       /// @param[in] fmt output file format
       /// @return true on succes
-      virtual bool dump(FILE *file, const char *var_name,
-        EMatrixDumpFormat fmt = DF_MATLAB_SPARSE, char* number_format = "%lf") = 0;
+      virtual bool dump(char *filename, const char *var_name,
+        EMatrixDumpFormat fmt = DF_PLAIN_ASCII, char* number_format = "%lf") = 0;
 
     protected:
       /// size of vector

--- a/hermes_common/include/solvers/epetra.h
+++ b/hermes_common/include/solvers/epetra.h
@@ -85,7 +85,7 @@ namespace Hermes
       
       virtual void add_as_block(unsigned int i, unsigned int j, EpetraMatrix<Scalar>* mat);
       virtual void add(unsigned int m, unsigned int n, Scalar **mat, int *rows, int *cols);
-      virtual bool dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt = DF_MATLAB_SPARSE, char* number_format = "%lf");
+      virtual bool dump(char *filename, const char *var_name, EMatrixDumpFormat fmt = DF_PLAIN_ASCII, char* number_format = "%lf");
       virtual unsigned int get_matrix_size() const;
       virtual unsigned int get_nnz() const;
       virtual double get_fill_in() const;
@@ -123,7 +123,7 @@ namespace Hermes
       virtual void set(unsigned int idx, Scalar y);
       virtual void add(unsigned int idx, Scalar y);
       virtual void add(unsigned int n, unsigned int *idx, Scalar *y);
-      virtual bool dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt = DF_MATLAB_SPARSE, char* number_format = "%lf");
+      virtual bool dump(char *filename, const char *var_name, EMatrixDumpFormat fmt = DF_PLAIN_ASCII, char* number_format = "%lf");
 
     protected:
       Epetra_BlockMap *std_map;

--- a/hermes_common/include/solvers/mumps_solver.h
+++ b/hermes_common/include/solvers/mumps_solver.h
@@ -86,7 +86,7 @@ namespace Hermes
       virtual void add(unsigned int m, unsigned int n, Scalar v);
       virtual void add_to_diagonal(Scalar v);
       virtual void add(unsigned int m, unsigned int n, Scalar **mat, int *rows, int *cols);
-      virtual bool dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt = DF_MATLAB_SPARSE, char* number_format = "%lf");
+      virtual bool dump(char *filename, const char *var_name, EMatrixDumpFormat fmt = DF_PLAIN_ASCII, char* number_format = "%lf");
       virtual unsigned int get_matrix_size() const;
       virtual unsigned int get_nnz() const;
       virtual double get_fill_in() const;
@@ -120,7 +120,7 @@ namespace Hermes
       int *jcn;         ///< Column indices.
       typename mumps_type<Scalar>::mumps_Scalar *Ax; ///< Matrix entries (column-wise).
       int *Ai;          ///< Row indices of values in Ax.
-      unsigned int *Ap;          ///< Index to Ax/Ai, where each column starts.
+      int *Ap;          ///< Index to Ax/Ai, where each column starts.
 
       friend class Solvers::MumpsSolver<Scalar>;
       template<typename T> friend SparseMatrix<T>*  create_matrix();
@@ -145,7 +145,7 @@ namespace Hermes
       virtual void add(unsigned int n, unsigned int *idx, Scalar *y);
       virtual void add_vector(Vector<Scalar>* vec);
       virtual void add_vector(Scalar* vec);
-      virtual bool dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt = DF_MATLAB_SPARSE, char* number_format = "%lf");
+      virtual bool dump(char *filename, const char *var_name, EMatrixDumpFormat fmt = DF_PLAIN_ASCII, char* number_format = "%lf");
 
     protected:
       // MUMPS specific data structures for storing the rhs.

--- a/hermes_common/include/solvers/paralution_solver.h
+++ b/hermes_common/include/solvers/paralution_solver.h
@@ -96,7 +96,7 @@ namespace Hermes
       virtual void add(unsigned int n, unsigned int *idx, Scalar *y);
       virtual void add_vector(Vector<Scalar>* vec);
       virtual void add_vector(Scalar* vec);
-      virtual bool dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt = DF_MATLAB_SPARSE, char* number_format = "%lf");
+      virtual bool dump(char *filename, const char *var_name, EMatrixDumpFormat fmt = DF_PLAIN_ASCII, char* number_format = "%lf");
 
       paralution::LocalVector<Scalar>& get_paralutionVector();
 

--- a/hermes_common/include/solvers/petsc_solver.h
+++ b/hermes_common/include/solvers/petsc_solver.h
@@ -59,7 +59,7 @@ namespace Hermes
       virtual void add(unsigned int m, unsigned int n, Scalar v);
       virtual void add_to_diagonal(Scalar v);
       virtual void add(unsigned int m, unsigned int n, Scalar **mat, int *rows, int *cols);
-      virtual bool dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt = DF_MATLAB_SPARSE, char* number_format = "%lf");
+      virtual bool dump(char *filename, const char *var_name, EMatrixDumpFormat fmt = DF_PLAIN_ASCII, char* number_format = "%lf");
       virtual unsigned int get_matrix_size() const;
       virtual unsigned int get_nnz() const;
       virtual double get_fill_in() const;
@@ -128,7 +128,7 @@ namespace Hermes
       virtual void add(unsigned int n, unsigned int *idx, Scalar *y);
       virtual void add_vector(Vector<Scalar>* vec);
       virtual void add_vector(Scalar* vec);
-      virtual bool dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt = DF_MATLAB_SPARSE, char* number_format = "%lf");
+      virtual bool dump(char *filename, const char *var_name, EMatrixDumpFormat fmt = DF_PLAIN_ASCII, char* number_format = "%lf");
 
     protected:
       /// Petsc vectore data structure.

--- a/hermes_common/include/solvers/superlu_solver.h
+++ b/hermes_common/include/solvers/superlu_solver.h
@@ -110,7 +110,7 @@ namespace Hermes
       virtual void add(unsigned int m, unsigned int n, Scalar v);
       virtual void add_to_diagonal(Scalar v);
       virtual void add(unsigned int m, unsigned int n, Scalar **mat, int *rows, int *cols);
-      virtual bool dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt = DF_MATLAB_SPARSE, char* number_format = "%lf");
+      virtual bool dump(char *filename, const char *var_name, EMatrixDumpFormat fmt = DF_PLAIN_ASCII, char* number_format = "%lf");
       virtual unsigned int get_matrix_size() const;
       virtual unsigned int get_nnz() const;
       virtual double get_fill_in() const;
@@ -176,7 +176,7 @@ namespace Hermes
       virtual void add(unsigned int n, unsigned int *idx, Scalar *y);
       virtual void add_vector(Vector<Scalar>* vec);
       virtual void add_vector(Scalar* vec);
-      virtual bool dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt = DF_MATLAB_SPARSE, char* number_format = "%lf");
+      virtual bool dump(char *filename, const char *var_name, EMatrixDumpFormat fmt = DF_PLAIN_ASCII, char* number_format = "%lf");
 
     protected:
       /// SUPERLU specific data structures for storing the rhs.

--- a/hermes_common/include/solvers/umfpack_solver.h
+++ b/hermes_common/include/solvers/umfpack_solver.h
@@ -76,7 +76,7 @@ namespace Hermes
       virtual void set_vector(Scalar* vec);
       virtual void add_vector(Vector<Scalar>* vec);
       virtual void add_vector(Scalar* vec);
-      virtual bool dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt = DF_MATLAB_SPARSE, char* number_format = "%lf");
+      virtual bool dump(char *filename, const char *var_name, EMatrixDumpFormat fmt = DF_PLAIN_ASCII, char* number_format = "%lf");
 
       /// @return pointer to array with vector data
       /// \sa #v

--- a/hermes_common/src/solvers/epetra.cpp
+++ b/hermes_common/src/solvers/epetra.cpp
@@ -327,7 +327,7 @@ namespace Hermes
     }
    
     template<>
-    bool EpetraMatrix<double>::dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
+    bool EpetraMatrix<double>::dump(char *filename, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
     {
       switch (fmt)
       {
@@ -341,7 +341,7 @@ namespace Hermes
     }
     
     template<>
-    bool EpetraMatrix<std::complex<double> >::dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
+    bool EpetraMatrix<std::complex<double> >::dump(char *filename, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
     {
       return false;
     }
@@ -474,7 +474,7 @@ namespace Hermes
     }
     
     template<>
-    bool EpetraVector<double>::dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
+    bool EpetraVector<double>::dump(char *filename, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
     {
       switch (fmt)
       {
@@ -488,7 +488,7 @@ namespace Hermes
     }
     
     template<>
-    bool EpetraVector<std::complex<double> >::dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
+    bool EpetraVector<std::complex<double> >::dump(char *filename, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
     {
       return false;
     }

--- a/hermes_common/src/solvers/petsc_solver.cpp
+++ b/hermes_common/src/solvers/petsc_solver.cpp
@@ -211,7 +211,7 @@ namespace Hermes
     }
 
     template<typename Scalar>
-    bool PetscMatrix<Scalar>::dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
+    bool PetscMatrix<Scalar>::dump(char *filename, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
     {
       switch (fmt)
       {
@@ -446,7 +446,7 @@ namespace Hermes
     }
 
     template<typename Scalar>
-    bool PetscVector<Scalar>::dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
+    bool PetscVector<Scalar>::dump(char *filename, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
     {
       switch (fmt)
       {

--- a/hermes_common/src/solvers/superlu_solver.cpp
+++ b/hermes_common/src/solvers/superlu_solver.cpp
@@ -222,7 +222,7 @@ namespace Hermes
     /// Save matrix and right-hand side to a file.
     ///
     template<typename Scalar>
-    bool SuperLUMatrix<Scalar>::dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
+    bool SuperLUMatrix<Scalar>::dump(char *filename, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
     {
       // TODO
       switch (fmt)
@@ -482,7 +482,7 @@ namespace Hermes
     }
 
     template<typename Scalar>
-    bool SuperLUVector<Scalar>::dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
+    bool SuperLUVector<Scalar>::dump(char *filename, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
     {
       switch (fmt)
       {

--- a/hermes_common/src/solvers/umfpack_solver.cpp
+++ b/hermes_common/src/solvers/umfpack_solver.cpp
@@ -155,45 +155,46 @@ namespace Hermes
     }
 
     template<>
-    bool UMFPackVector<double>::dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
+    bool UMFPackVector<double>::dump(char *filename, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
     {
       switch (fmt)
       {
-      case DF_MATLAB_SPARSE:
-        fprintf(file, "%% Size: %dx1\n%s =[\n", this->size, var_name);
-        for (unsigned int i = 0; i < this->size; i++)
-        {
-          Hermes::Helpers::fprint_num(file, v[i], number_format);
-          fprintf(file, "\n");
-        }
-        fprintf(file, " ];\n");
-        return true;
 
-      case DF_HERMES_BIN:
-        {
-          hermes_fwrite("HERMESR\001", 1, 8, file);
-          int ssize = sizeof(double);
-          hermes_fwrite(&ssize, sizeof(int), 1, file);
-          hermes_fwrite(&this->size, sizeof(int), 1, file);
-          hermes_fwrite(v, sizeof(double), this->size, file);
-          return true;
-        }
+      case DF_MATLAB_MAT:
+      {
+#ifdef WITH_MATIO
+        size_t dims[2];
+        dims[0] = this->size;
+        dims[1] = 1;
 
-      case DF_HERMES_MATLAB_BIN:
+        mat_t *mat = Mat_CreateVer(filename, NULL, MAT_FT_MAT5);
+        matvar_t *matvar = Mat_VarCreate("rhs", MAT_C_DOUBLE, MAT_T_DOUBLE, 2, dims, v, MAT_F_DONT_COPY_DATA);
+        if (matvar)
         {
-          hermes_fwrite(&this->size, sizeof(int), 1, file);
-          hermes_fwrite(v, sizeof(double), this->size, file);
-          return true;
+            Mat_VarWrite(mat, matvar, MAT_COMPRESSION_ZLIB);
+            Mat_VarFree(matvar);
+
+            return true;
         }
+        else
+        {
+            return false;
+        }
+        Mat_Close(mat);
+#endif
+        return false;
+      }
 
       case DF_PLAIN_ASCII:
         {
+          FILE* file = fopen(filename, "w+");
           fprintf(file, "\n");
           for (unsigned int i = 0; i < size; i++)
           {
             Hermes::Helpers::fprint_num(file, v[i], number_format);
             fprintf(file, "\n");
           }
+          fclose(file);
 
           return true;
         }
@@ -204,37 +205,19 @@ namespace Hermes
     }
 
     template<>
-    bool UMFPackVector<std::complex<double> >::dump(FILE *file, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
+    bool UMFPackVector<std::complex<double> >::dump(char *filename, const char *var_name, EMatrixDumpFormat fmt, char* number_format)
     {
       switch (fmt)
       {
-      case DF_MATLAB_SPARSE:
-        fprintf(file, "%% Size: %dx1\n%s =[\n", this->size, var_name);
-        for (unsigned int i = 0; i < this->size; i++)
-        {
-          Hermes::Helpers::fprint_num(file, v[i], number_format);
-          fprintf(file, "\n");
-        }
-        fprintf(file, " ];\n");
-        return true;
-
-      case DF_HERMES_BIN:
-        {
-          hermes_fwrite("HERMESR\001", 1, 8, file);
-          int ssize = sizeof(std::complex<double>);
-          hermes_fwrite(&ssize, sizeof(int), 1, file);
-          hermes_fwrite(&this->size, sizeof(int), 1, file);
-          hermes_fwrite(v, sizeof(std::complex<double>), this->size, file);
-          return true;
-        }
-
       case DF_PLAIN_ASCII:
         {
+          FILE* file = fopen(filename, "w+");
           fprintf(file, "\n");
           for (unsigned int i = 0; i < size; i++)
           {
             fprintf(file, "%E %E\n", v[i].real(), v[i].imag());
           }
+          fclose(file);
 
           return true;
         }


### PR DESCRIPTION
 (MUMPS, UMFACK, PARALUTION)

DF_PLAIN_ASCII - removed lines with size and nzz (it should be loaded to MATLAB using "load matrix.dat; A = spconvert(matrix)")
DF_MATLAB_SPARSE - deleted
DF_MATLAB_MAT - MATLAB 5.0 format
DF_MATRIX_MARKET - not tested

http://sourceforge.net/projects/matio/
